### PR TITLE
Uses typeahead component for reference system

### DIFF
--- a/src/main/plugin/iso19139.nl.services.2.0.0/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.nl.services.2.0.0/layout/config-editor.xml
@@ -774,8 +774,10 @@
 
           <!--     5.27 Code referentiesysteem ... -->
           <field name="rsIdentifier" or="code"
+                 use="data-gn-keyword-picker"
                  xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:code"
                  del="../../../..">
+            <directiveAttributes data-thesaurus-key="external.theme.projections" data-thesaurus-concept-id-attribute="xlinkCOLONhref"/>
           </field>
           <action type="add" del="."
                   btnLabel="addReferenceSystem"
@@ -790,7 +792,7 @@
                       <gmd:RS_Identifier>
                         <gmd:code>
                           <gmx:Anchor
-                            xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Amersfoort / RD New</gmx:Anchor>
+                            xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992"></gmx:Anchor>
                         </gmd:code>
                       </gmd:RS_Identifier>
                     </gmd:referenceSystemIdentifier>

--- a/src/main/plugin/iso19139.nl.services.2.0.0/templates/ISO19119services2.0.xml
+++ b/src/main/plugin/iso19139.nl.services.2.0.0/templates/ISO19119services2.0.xml
@@ -91,7 +91,7 @@
         <gmd:referenceSystemIdentifier>
           <gmd:RS_Identifier>
             <gmd:code>
-              <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Amersfoort / RD New</gmx:Anchor>
+              <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Rijks Driehoeksstelsel</gmx:Anchor>
             </gmd:code>
           </gmd:RS_Identifier>
         </gmd:referenceSystemIdentifier>


### PR DESCRIPTION
* Use a typeahead component for reference system based on external.themes.projections codelist.
* Change the default projetion in the template to `Rijks Driehoeksstelse`.